### PR TITLE
Detect Padrino

### DIFF
--- a/framework.go
+++ b/framework.go
@@ -4,6 +4,7 @@ package catfruits
 var DefaultFrameworkFuncs = map[string]FrameworkFunc{
 	// Ruby
 	"Ruby on Rails": fwRails,
+	"Padrino":       fwPadrino,
 
 	// JavaScript
 	"Vue":      fwJSGen("vue"),
@@ -20,6 +21,10 @@ func fwRails(sc *Scanner) (bool, error) {
 	return sc.hasPackage("gem", "rails") ||
 		sc.FileExist("script/rails") ||
 		sc.FileExist("bin/rails"), nil
+}
+
+func fwPadrino(sc *Scanner) (bool, error) {
+	return sc.FileContains("config/apps.rb", "Padrino") || sc.FileContains("config/boot.rb", "Padrino"), nil
 }
 
 // bower と npm から探索する関数をかえす

--- a/framework_test.go
+++ b/framework_test.go
@@ -14,6 +14,10 @@ func TestFWVue(t *testing.T) {
 	fwTestHelper("Vue", "vue/npm", t)
 }
 
+func TestFWPadrino(t *testing.T) {
+	fwTestHelper("Padrino", "padrino", t)
+}
+
 func fwTestHelper(name, branch string, t *testing.T) {
 	exec.Command("bash", "-c", fmt.Sprintf("cd %s; git checkout %s", sandboxDir, branch)).Run()
 	sc := NewScanner(sandboxDir)

--- a/helpers.go
+++ b/helpers.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // ----------- Helper functions
@@ -37,4 +38,12 @@ func (sc *Scanner) hasPackage(pkg, name string) bool {
 		}
 	}
 	return false
+}
+
+func (sc *Scanner) FileContains(path, content string) bool {
+	b, err := sc.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(b), content)
 }


### PR DESCRIPTION
#1
# Padrino で作られたApplication例
- https://github.com/motdotla/mottemuseum
- https://github.com/tyabe/kpt-it
# Padrino で新規プロジェクトを始める例

[Rails ＋ Sinatra ≒ Padrino で遊ぼう！ » 梨木を読む](http://cyberwave.jp/nashiki/2010/06/rails-%EF%BC%8B-sinatra-%E2%89%92-padrino-%E3%81%A7%E9%81%8A%E3%81%BC%E3%81%86%EF%BC%81/)
# 検出方法
- `config/apps.rb` か `config/boot.rb` の中に`Padrino`が含まれているかをチェック
